### PR TITLE
feat: refactor consensusVersion

### DIFF
--- a/x/zenbtc/module/module.go
+++ b/x/zenbtc/module/module.go
@@ -22,6 +22,8 @@ import (
 	"github.com/zenrocklabs/zenbtc/x/zenbtc/types"
 )
 
+const consensusVersion = 1
+
 var (
 	_ module.AppModuleBasic      = (*AppModule)(nil)
 	_ module.AppModuleSimulation = (*AppModule)(nil)
@@ -144,7 +146,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 // ConsensusVersion is a sequence number for state-breaking change of the module.
 // It should be incremented on each consensus-breaking change introduced by the module.
 // To avoid wrong/empty versions, the initial version should be set to 1.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return consensusVersion }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 // The begin block implementation is optional.


### PR DESCRIPTION
We are highlighting the `consensusVersion` declaration to make it more visible and follow the same patters for module migrations as the other modules in zrchain.