### PR TITLE
feat: spent utxos

### DIFF
--- a/x/zenbtc/keeper/keeper.go
+++ b/x/zenbtc/keeper/keeper.go
@@ -2,13 +2,11 @@ package keeper
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/log"
+	"errors"
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/zenrocklabs/zenbtc/x/zenbtc/types"
 
@@ -129,18 +127,6 @@ func (k Keeper) SetRedemption(ctx context.Context, id uint64, redemption types.R
 
 func (k Keeper) WalkRedemptions(ctx context.Context, fn func(id uint64, redemption types.Redemption) (stop bool, err error)) error {
 	return k.Redemptions.Walk(ctx, nil, fn)
-}
-
-func (k *Keeper) SetUTXOUsed(ctx sdk.Context, txid string, index uint64) error {
-	return k.UTXOSpent.Set(ctx, collections.Join(txid, index), true)
-}
-
-func (k *Keeper) HasUTXOUsed(ctx sdk.Context, txid string, index uint64) (bool, error) {
-	exist, err := k.UTXOSpent.Get(ctx, collections.Join(txid, index))
-	if err != nil {
-		return false, err
-	}
-	return exist, nil
 }
 
 func (k Keeper) GetSupply(ctx context.Context) (types.Supply, error) {

--- a/x/zenbtc/types/keys.go
+++ b/x/zenbtc/types/keys.go
@@ -23,6 +23,7 @@ var (
 	BurnEventsKey                  = collections.NewPrefix(6)
 	PendingMintTransactionsMapKey  = collections.NewPrefix(7)
 	BurnEventCountKey              = collections.NewPrefix(8)
+	UTXOSpentKey                   = collections.NewPrefix(9)
 
 	ParamsIndex                      = "params"
 	LockTransactionsIndex            = "lock_transactions"
@@ -33,4 +34,5 @@ var (
 	BurnEventsIndex                  = "burn_events"
 	PendingMintTransactionsMapIndex  = "pending_mint_transactions_map"
 	BurnEventCountIndex              = "burn_event_count"
+	UTXOSpentIndex                   = "redemption_utxo_usage"
 )


### PR DESCRIPTION
track UTXOs spent in BTC redemption transactions, and reject transaction before double spend error caused by duplicate transactions from different proxies.