### PR TITLE
fix: Iterate redemptionIndexes starting from index 1 (not 0)

### DIFF
--- a/x/zenbtc/keeper/msg_server_submit_unsigned_redemption_tx.go
+++ b/x/zenbtc/keeper/msg_server_submit_unsigned_redemption_tx.go
@@ -62,7 +62,7 @@ func (k msgServer) SubmitUnsignedRedemptionTx(goCtx context.Context, msg *types.
 		return nil, err
 	}
 
-	for _, idx := range msg.RedemptionIndexes {
+	for _, idx := range msg.RedemptionIndexes[1:] {
 		redemption, err := k.Redemptions.Get(ctx, idx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Having an unused index is designed to match BTC Transaction VOuts to Redemption Indexes without any offset